### PR TITLE
Test bootstrap fix / LEFT JOIN fix

### DIFF
--- a/lib/custom/src/MShop/Customer/Manager/Property/Laravel.php
+++ b/lib/custom/src/MShop/Customer/Manager/Property/Laravel.php
@@ -24,7 +24,7 @@ class Laravel
 		'customer.property.id' => array(
 			'code' => 'customer.property.id',
 			'internalcode' => 'lvupr."id"',
-			'internaldeps'=>array( 'LEFT JOIN "users_property" AS lvupr ON ( lvupr."parentid" = fos."id" )' ),
+			'internaldeps'=>array( 'LEFT JOIN "users_property" AS lvupr ON ( lvupr."parentid" = lvu."id" )' ),
 			'label' => 'Property ID',
 			'type' => 'integer',
 			'internaltype' => \Aimeos\MW\DB\Statement\Base::PARAM_INT,

--- a/lib/custom/tests/TestHelper.php
+++ b/lib/custom/tests/TestHelper.php
@@ -36,7 +36,7 @@ class TestHelper
 	{
 		if( !isset( self::$aimeos ) )
 		{
-			require_once 'Bootstrap.php';
+			require_once 'bootstrap.php';
 			spl_autoload_register( 'Aimeos\\Bootstrap::autoload' );
 
 			$extdir = dirname( dirname( dirname( __DIR__ ) ) );


### PR DESCRIPTION
I updated a file name in a `require_once()` statement in `TestHelper.php`. I work on a case-sensitive partition on OS and the file would not load because it was typed as `Bootstrap.php` but the filename is `bootstrap.php`.

Secondly, I ran into an error where getting a customer propery values would cause an SQL error on the LEFT JOIN. My error occured on the following case:

```
$context = app()->make('\Aimeos\Shop\Base\Context')->get();
$manager = \Aimeos\MShop\Customer\Manager\Factory::createManager($context);
$search = $manager->createSearch(true);

$expr = [
    $search->compare('==', 'customer.property.type.code', 'oauth_token'),
    $search->compare('==', 'customer.property.value', $token),
    $search->getConditions(),
];

$search->setConditions($search->combine('&&', $expr));

foreach ($manager->searchItems($search) as $id => $item) {
    dump($id, $item->getResourceType(), $item);
}
```

The join was made on `(lvupr."parentid" = fos."id")`, but the customer table alias used is `luv`.
